### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/seed_trending_music.yml
+++ b/.github/workflows/seed_trending_music.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
     # Allows manual triggering from the GitHub Actions UI
 
+permissions:
+  contents: read
+
 jobs:
   seed_trending_music:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Agrannya-Singh/Tune_Trace_backend/security/code-scanning/10](https://github.com/Agrannya-Singh/Tune_Trace_backend/security/code-scanning/10)

Add an explicit `permissions` block at the workflow root so it applies to all jobs in this workflow. For this pipeline, the minimal required scope is `contents: read` (sufficient for repository checkout). This preserves current behavior while enforcing least privilege and satisfying the CodeQL rule.

**File to edit:** `.github/workflows/seed_trending_music.yml`  
**Change location:** after the `on:` trigger section (or immediately after `name:`), before `jobs:`.  
**Required additions:** YAML key:
```yml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security of automated workflows by restricting token permissions to read-only access for repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->